### PR TITLE
feat(features): add htmlType to button

### DIFF
--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -7,7 +7,16 @@ export const Button: React.FC<{
     onClick?: (() => void) | ((e: SyntheticEvent) => void);
     disabled?: boolean;
     name?: string;
-}> = ({ children, type = 'primary', size = 'medium', onClick, disabled = false, name }) => {
+    htmlType?: 'button' | 'submit' | 'reset';
+}> = ({
+    children,
+    type = 'primary',
+    size = 'medium',
+    onClick,
+    disabled = false,
+    name,
+    htmlType,
+}) => {
     const className = `${styles.button} ${
         type === 'primary' ? styles.button_type_primary : styles.button_type_secondary
     } ${
@@ -19,7 +28,13 @@ export const Button: React.FC<{
     }`;
 
     return (
-        <button disabled={disabled} name={name} onClick={onClick} className={className}>
+        <button
+            type={htmlType}
+            disabled={disabled}
+            name={name}
+            onClick={onClick}
+            className={className}
+        >
             {children}
         </button>
     );


### PR DESCRIPTION
На основании этого треда в [слэке](https://praktikum-web.slack.com/archives/C01U39SAVNC/p1634807631009100?thread_ts=1634803163.007800&cid=C01U39SAVNC), вкратце:

> Но  есть небольшая проблема. В форме редактирования профиля есть две кнопки "Отмена" и "Сохранить", в ui библиотеке сейчас нельзя задать тип кнопки, она всегда submit. Получается, если вешать обработчик на submit формы, то при сабмите вызывается так же клик  по кнопке, а т.к. обе кнопки submit , то срабатывает кнопка "отмена".

Поскольку проп type уже существовал, для сохранения API назвал htmlType по аналогии с [htmlFor](https://reactjs.org/docs/dom-elements.html#htmlfor)

Если есть предложения по нэймингу или готовность переименовать `type` на `kind` и назвать добавленный проп `type`, буду рад 👍 