### PR TITLE
fix: change type of onClick for Tab

### DIFF
--- a/src/ui/tab.tsx
+++ b/src/ui/tab.tsx
@@ -6,7 +6,7 @@ export const Tab: React.FC<
     React.PropsWithChildren<{
         active: boolean;
         value: string;
-        onClick: (value: string) => void;
+        onClick?: (value: string) => void;
     }>
 > = ({ active, value, children, onClick: handleClick }) => {
     const className = clsx(


### PR DESCRIPTION
Есть вариант реализации табов с использованием якорей и Intersection Observer:

```tsx
//BurgerIngredients.tsx

import { useEffect, useState } from 'react';
import { useTypedSelector } from '@/services';
import { useInView } from 'react-intersection-observer';
import cls from './BurgerIngredients.module.css';
import { Modal } from '../Modal/Modal';
import { IngredientDetails } from './IngredientDetails/IngredientDetails';
import { selectModal } from '../../services/selectors/modalSelectors';
import { Tabs } from './Tabs/Tabs';
import { IngredientsSection } from './IngredientsSection/IngredientsSection';
import { IngredientType } from '@/shared/types/api';

interface ingredientsSectionType {
  type: IngredientType;
  title: 'Булки' | 'Соусы' | 'Начинки';
  ref: (node?: Element | null) => void;
}

export const BurgerIngredients = () => {
  const [currentTab, setCurrentTab] = useState<IngredientType>('bun');
  const { isModalOpen, modalType, modalContent } = useTypedSelector(selectModal);

  const { ref: bunsRef, inView: bunsInView } = useInView();
  const { ref: saucesRef, inView: saucesInView } = useInView();
  const { ref: mainRef, inView: mainInView } = useInView();

  useEffect(() => {
    if (bunsInView) {
      setCurrentTab('bun');
    } else if (saucesInView) {
      setCurrentTab('sauce');
    } else if (mainInView) {
      setCurrentTab('main');
    }
  }, [bunsInView, saucesInView, mainInView]);

  const ingredientsSections: ingredientsSectionType[] = [
    { type: 'bun', title: 'Булки', ref: bunsRef },
    { type: 'sauce', title: 'Соусы', ref: saucesRef },
    { type: 'main', title: 'Начинки', ref: mainRef },
  ];

  return (
    <>
      <section className={cls.wrapp}>
        <Tabs currentTab={currentTab} />
        <div className={cls.ingredients}>
          {ingredientsSections.map((section) => (
            <IngredientsSection type={section.type} title={section.title} ref={section.ref} key={section.type} />
          ))}
        </div>
      </section>
      {isModalOpen && modalType === 'IngredientDetails' &&  (
        <Modal title='Детали ингредиента'>
          <IngredientDetails {...modalContent} />
        </Modal>
      )}
    </>
  );
};
```

А из-за того, что onClick обязательный пропс в типах компонента Tab, приходится использовать {/* @ts-expect-error onClick is required */}:

```tsx
//Tabs.tsx

import { Tab } from '@ya.praktikum/react-developer-burger-ui-components';
import { memo } from 'react';
import cls from './Tabs.module.css';
import { IngredientType } from '@/shared/types/api';

interface Props {
  currentTab: IngredientType;
}

export const Tabs = memo(({ currentTab }: Props) => {
  return (
    <nav className='mb-10'>
      <ul className={cls.nav_list}>
        <li className={cls.nav_item}>
          <a href='#bun'>
            {/* @ts-expect-error onClick is required */}
            <Tab value='bun' active={currentTab === 'bun'}>
              Булки
            </Tab>
          </a>
        </li>
        <li className={cls.nav_item}>
          <a href='#sauce'>
            {/* @ts-expect-error onClick is required */}
            <Tab value='sauce' active={currentTab === 'sauce'}>
              Соусы
            </Tab>
          </a>
        </li>
        <li className={cls.nav_item}>
          <a href='#main'>
            {/* @ts-expect-error onClick is required */}
            <Tab value='main' active={currentTab === 'main'}>
              Начинки
            </Tab>
          </a>
        </li>
      </ul>
    </nav>
  );
});
```
